### PR TITLE
Fix testss

### DIFF
--- a/Content.Server/ADT/Administration/Systems/AdminADTSmitesVerbs.cs
+++ b/Content.Server/ADT/Administration/Systems/AdminADTSmitesVerbs.cs
@@ -121,7 +121,7 @@ public sealed partial class AdminVerbSystem
             {
                 Text = superBoostSpeedName,
                 Category = VerbCategory.Smite,
-                Icon = new SpriteSpecifier.Texture(new("Interface/Alerts/walking.rsi/walking.png")),
+                Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/Alerts/walking.rsi/walking.png")),
                 Act = () =>
                 {
                     var hadSlipComponent = TryComp<SpeedBoostWakeComponent>(args.Target, out var _);

--- a/Resources/Prototypes/ADT/Entities/Clothing/Head/modsuit-helmets.yml
+++ b/Resources/Prototypes/ADT/Entities/Clothing/Head/modsuit-helmets.yml
@@ -14,6 +14,12 @@
       visible: false
       shader: unshaded
       map: [ "light" ]
+  - type: ToggleableLightVisuals
+    spriteLayer: light
+    clothingVisuals:
+      head:
+      - state: equipped-head-light
+        shader: unshaded
   - type: Clothing
     clothingVisuals:
       head:

--- a/Resources/Prototypes/Entities/Clothing/Shoes/specific.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/specific.yml
@@ -114,6 +114,11 @@
     sprite: Clothing/Shoes/Specific/galoshes.rsi
   - type: Clothing
     sprite: Clothing/Shoes/Specific/galoshes.rsi
+    # ADT-Tweak start
+    clothingVisuals:
+      shoes:
+      - state: equipped-FEET
+    # ADT-Tweak end
   - type: NoSlip
   - type: SlowedOverSlippery
     slowdownModifier: 0.7

--- a/Resources/Prototypes/Entities/Clothing/Uniforms/jumpsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/jumpsuits.yml
@@ -406,6 +406,13 @@
   components:
   - type: Sprite
     sprite: Clothing/Uniforms/Jumpsuit/janitor.rsi
+  # ADT-Tweak start
+  - type: Clothing
+    sprite: Clothing/Uniforms/Jumpsuit/janitor.rsi
+    clothingVisuals:
+      jumpsuit:
+      - state: equipped-INNERCLOTHING
+  # ADT-Tweak end
 
 - type: entity
   parent: ClothingUniformBase


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed icon display path for the admin speed-boost smite verb.

* **New Features**
  * Added togglable light visual effects to mod suit helmets for enhanced item customization and appearance options.
  * Implemented proper visual rendering states for galoshes when equipped on feet during gameplay.
  * Extended the janitor jumpsuit appearance system with additional inner-clothing equipped visual variants and state support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->